### PR TITLE
README: Add concise algorithm summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ The Toorani-Beheshti signcryption scheme achieves this using a single key pair p
 - `info`: this describes the context in which a message was sent. Signature verification will fail if the context expected by the verifier doesn't match the one the signature was origially created for.
 - `shared_key`: a shared secret key, used for encryption. The scheme only generates shared secrets; applications are free to use them with the encryption system of their choice.
 
+## Algorithm summary
+
+```
+(a,A) = sender_sk, sender_pk
+(b,B) = recipent_sk, recipient_pk
+
+    r = H("nonce",sender_sk,recipient_pk,noise,plaintext)
+    R = rG
+    K = (ra + r)B
+    x = H("shared_key",K,sender_id,recipient_id,info)
+    y = H("sign_key",R,sender_id,recipient_id,info,ciphertext)
+    R = rG
+    s = ya - r
+
+ sign = (R,s) = (rG,ya-r)
+
+    K = b(RA + R)
+    S = (sG + R)A
+```
+
 ## Source code
 
 - The `src/tbsbr` directory contains the main source code, with the scheme implemented using the BLAKE2b hash function and the Ristretto255 group. This is the recommended version.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The Toorani-Beheshti signcryption scheme achieves this using a single key pair p
 
     K = b(RA + R)
     S = (sG + R)A
+
+ alternatively:
+
+    S = A^2 + R
 ```
 
 ## Source code


### PR DESCRIPTION
Hi Frank,

This is the algorithm summary I tweeted to you the other day.

Since the version I sent via twitter, I've moved the private key to the left in the multiplication for `S` to match the notation convention in the Toorani-Beheshti paper. The variable names might not be exactly the same so you might want to fine-tune this if you think it's worthwhile adding this summary.

I've deliberately used a lowercase `s` in `(R,s)` for the signature component because it is not on the group. This is mentioned in the commit message, but I've mentioned it again here. This is because it was (at least for me) important for my understanding of the algorithm assuming I understand it correctly. 

There is a squaring of `a` which is not shown explicitly? which might be like this?

```
    S = A^2 + R
```

Michael

--
https://keybase.io/michaeljclark