### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Toorani-Beheshti signcryption scheme achieves this using a single key pair p
 
     r = H("nonce", sender_sk, recipient_pk, noise, plaintext)
     R = rG
-    K = (ra + r)B
+    K = (Ra + r)B
     x = H("shared_key", K, sender_id, recipient_id, info)
     y = H("sign_key", R, sender_id, recipient_id, info, ciphertext)
     R = rG


### PR DESCRIPTION
Hi,
I think there is a small typo in the README.md. 
The equation `K = (ra + r)B` probably needs to be replaced with `K = (Ra + r)B` .
Also in the code `R` is used instead of `r`: https://github.com/jedisct1/libsodium-signcryption/blob/a1aa02b7d1131e6dffc40c1caf0e61e289d8e3bb/src/tbsbr/signcrypt_tbsbr.c line 66 - 71